### PR TITLE
Harden favorites access control and improve frontend sync

### DIFF
--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -60,6 +60,7 @@ model Favorite {
   user   User   @relation("UserFavorites", fields: [userId], references: [githubId])
   tool   Tool   @relation(fields: [toolId], references: [id])
 
+  @@unique([userId, toolId])
   @@map("favorites")
 }
 

--- a/api/src/app/app.module.ts
+++ b/api/src/app/app.module.ts
@@ -7,7 +7,8 @@ import { ToolsModule } from 'src/tools/tools.module';
 import { UsersModule } from 'src/users/users.module';
 import { FavoritesModule } from 'src/favorites/favorites.module';
 import { SuggestionsModule } from 'src/suggestions/suggestions.module';
-import { ThrottlerModule } from '@nestjs/throttler';
+import { ThrottlerModule, ThrottlerGuard } from '@nestjs/throttler';
+import { APP_GUARD } from '@nestjs/core';
 
 @Module({
   imports: [PrismaModule, CategoriesModule, ToolsModule, UsersModule, FavoritesModule, SuggestionsModule,
@@ -17,6 +18,12 @@ import { ThrottlerModule } from '@nestjs/throttler';
     }]),
   ],
   controllers: [AppController],
-  providers: [AppService],
+  providers: [
+    AppService,
+    {
+      provide: APP_GUARD,
+      useClass: ThrottlerGuard,
+    },
+  ],
 })
 export class AppModule { }

--- a/api/src/common/decorators/current-user.decorator.ts
+++ b/api/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,23 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
+
+export const CurrentUser = createParamDecorator(
+  (data: keyof AuthenticatedUser | undefined, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest<{ user?: AuthenticatedUser }>();
+    const user = request.user;
+
+    if (!user) {
+      throw new UnauthorizedException('User not found in request context');
+    }
+
+    if (data) {
+      return user[data];
+    }
+
+    return user;
+  },
+);

--- a/api/src/common/guards/authenticated-user.guard.ts
+++ b/api/src/common/guards/authenticated-user.guard.ts
@@ -1,0 +1,36 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { AuthenticatedUser } from '../interfaces/authenticated-user.interface';
+
+@Injectable()
+export class AuthenticatedUserGuard implements CanActivate {
+  canActivate(context: ExecutionContext): boolean {
+    const request = context.switchToHttp().getRequest<
+      Request & { user?: AuthenticatedUser }
+    >();
+
+    const headerValue = request.headers['x-user-id'];
+    const userIdHeader = Array.isArray(headerValue)
+      ? headerValue[0]
+      : headerValue;
+
+    if (!userIdHeader) {
+      throw new UnauthorizedException('Missing user identifier');
+    }
+
+    const parsedUserId = Number.parseInt(userIdHeader, 10);
+
+    if (Number.isNaN(parsedUserId) || parsedUserId <= 0) {
+      throw new UnauthorizedException('Invalid user identifier');
+    }
+
+    request.user = { id: parsedUserId };
+
+    return true;
+  }
+}

--- a/api/src/common/interfaces/authenticated-user.interface.ts
+++ b/api/src/common/interfaces/authenticated-user.interface.ts
@@ -1,0 +1,3 @@
+export interface AuthenticatedUser {
+  id: number;
+}

--- a/api/src/favorites/dto/create-favorite.dto.ts
+++ b/api/src/favorites/dto/create-favorite.dto.ts
@@ -1,16 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsNotEmpty, IsNumber, IsString, IsUUID } from 'class-validator';
+import { IsNotEmpty, IsUUID } from 'class-validator';
 
 export class CreateFavoriteDto {
-
-  @IsNotEmpty()
-  @IsNumber()
-  @ApiProperty({
-    description: 'The ID of the user who favorites the tool',
-    example: 'user-uuid',
-  })
-  userId: number;
-
   @IsNotEmpty()
   @IsUUID()
   @ApiProperty({

--- a/api/src/favorites/favorites.controller.spec.ts
+++ b/api/src/favorites/favorites.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FavoritesController } from './favorites.controller';
 import { FavoritesService } from './favorites.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('FavoritesController', () => {
   let controller: FavoritesController;
@@ -8,7 +9,13 @@ describe('FavoritesController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [FavoritesController],
-      providers: [FavoritesService],
+      providers: [
+        FavoritesService,
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<FavoritesController>(FavoritesController);

--- a/api/src/favorites/favorites.controller.ts
+++ b/api/src/favorites/favorites.controller.ts
@@ -2,39 +2,63 @@ import {
   Body,
   Controller,
   Delete,
+  ForbiddenException,
   Get,
   Param,
+  ParseIntPipe,
+  ParseUUIDPipe,
   Post,
   Query,
+  UseGuards,
 } from "@nestjs/common";
 import { CreateFavoriteDto } from "./dto/create-favorite.dto";
 import { FavoritesService } from "./favorites.service";
+import { AuthenticatedUserGuard } from "src/common/guards/authenticated-user.guard";
+import { CurrentUser } from "src/common/decorators/current-user.decorator";
+import { AuthenticatedUser } from "src/common/interfaces/authenticated-user.interface";
 
 @Controller("favorites")
 export class FavoritesController {
   constructor(private readonly favoritesService: FavoritesService) {}
 
+  @UseGuards(AuthenticatedUserGuard)
   @Post()
-  create(@Body() createFavoriteDto: CreateFavoriteDto) {
-    return this.favoritesService.create(createFavoriteDto);
+  create(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() createFavoriteDto: CreateFavoriteDto
+  ) {
+    return this.favoritesService.create(user.id, createFavoriteDto.toolId);
   }
 
+  @UseGuards(AuthenticatedUserGuard)
   @Get("check")
   checkFavorite(
-    @Query("userId") userId: string,
-    @Query("toolId") toolId: string
+    @CurrentUser("id") userId: number,
+    @Query("toolId", ParseUUIDPipe) toolId: string
   ) {
-    return this.favoritesService.checkFavorite(parseInt(userId), toolId);
+    return this.favoritesService.checkFavorite(userId, toolId);
   }
 
+  @UseGuards(AuthenticatedUserGuard)
   @Get("user/:userId")
-  getFavoritesByUserId(@Param("userId") userId: string) {
+  getFavoritesByUserId(
+    @Param("userId", ParseIntPipe) userId: number,
+    @CurrentUser("id") currentUserId: number
+  ) {
+    if (currentUserId !== userId) {
+      throw new ForbiddenException();
+    }
+
     return this.favoritesService.getFavoritesByUserId(userId);
   }
 
+  @UseGuards(AuthenticatedUserGuard)
   @Post("toggle")
-  toggleFavorite(@Body() body: { userId: number; toolId: string }) {
-    return this.favoritesService.toggleFavorite(body.userId, body.toolId);
+  toggleFavorite(
+    @CurrentUser("id") userId: number,
+    @Body("toolId", ParseUUIDPipe) toolId: string
+  ) {
+    return this.favoritesService.toggleFavorite(userId, toolId);
   }
 
   @Get(":id")

--- a/api/src/favorites/favorites.service.spec.ts
+++ b/api/src/favorites/favorites.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { FavoritesService } from './favorites.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('FavoritesService', () => {
   let service: FavoritesService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [FavoritesService],
+      providers: [
+        FavoritesService,
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<FavoritesService>(FavoritesService);

--- a/api/src/favorites/favorites.service.ts
+++ b/api/src/favorites/favorites.service.ts
@@ -1,26 +1,44 @@
-import { Injectable } from "@nestjs/common";
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from "@nestjs/common";
+import { Prisma } from "@prisma/client";
 import { PrismaService } from "src/prisma/prisma.service";
-import { CreateFavoriteDto } from "./dto/create-favorite.dto";
 import { UpdateFavoriteDto } from "./dto/update-favorite.dto";
 
 @Injectable()
 export class FavoritesService {
   constructor(private prisma: PrismaService) {}
 
-  async create(createFavoriteDto: CreateFavoriteDto) {
-    const { userId, toolId } = createFavoriteDto;
+  async create(userId: number, toolId: string) {
+    const [user, tool] = await Promise.all([
+      this.prisma.user.findUnique({ where: { githubId: userId } }),
+      this.prisma.tool.findUnique({ where: { id: toolId } }),
+    ]);
 
-    const toolExists = await this.prisma.tool.findUnique({
-      where: { id: toolId },
-    });
-
-    if (!toolExists) {
-      throw new Error("Tool not found");
+    if (!user) {
+      throw new NotFoundException("User not found");
     }
 
-    return this.prisma.favorite.create({
-      data: { userId, toolId },
-    });
+    if (!tool) {
+      throw new NotFoundException("Tool not found");
+    }
+
+    try {
+      return await this.prisma.favorite.create({
+        data: { userId, toolId },
+      });
+    } catch (error) {
+      if (
+        error instanceof Prisma.PrismaClientKnownRequestError &&
+        error.code === "P2002"
+      ) {
+        throw new ConflictException("Tool already favorited");
+      }
+
+      throw error;
+    }
   }
 
   findOne(id: string) {
@@ -28,27 +46,44 @@ export class FavoritesService {
   }
 
   async checkFavorite(userId: number, toolId: string) {
-    const favorite = await this.prisma.favorite.findFirst({
+    const favorite = await this.prisma.favorite.findUnique({
       where: {
-        userId,
-        toolId,
+        userId_toolId: {
+          userId,
+          toolId,
+        },
       },
     });
     return { isFavorite: !!favorite };
   }
 
-  async getFavoritesByUserId(userId: string) {
+  async getFavoritesByUserId(userId: number) {
     return this.prisma.favorite.findMany({
-      where: { userId: parseInt(userId) },
+      where: { userId },
       include: { tool: true },
     });
   }
 
   async toggleFavorite(userId: number, toolId: string) {
-    const existingFavorite = await this.prisma.favorite.findFirst({
+    const [user, tool] = await Promise.all([
+      this.prisma.user.findUnique({ where: { githubId: userId } }),
+      this.prisma.tool.findUnique({ where: { id: toolId } }),
+    ]);
+
+    if (!user) {
+      throw new NotFoundException("User not found");
+    }
+
+    if (!tool) {
+      throw new NotFoundException("Tool not found");
+    }
+
+    const existingFavorite = await this.prisma.favorite.findUnique({
       where: {
-        userId,
-        toolId,
+        userId_toolId: {
+          userId,
+          toolId,
+        },
       },
     });
 

--- a/api/src/prisma/prisma.service.ts
+++ b/api/src/prisma/prisma.service.ts
@@ -1,5 +1,15 @@
-import { INestApplication, Injectable } from '@nestjs/common';
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
 import { PrismaClient } from '@prisma/client';
 
 @Injectable()
-export class PrismaService extends PrismaClient { }
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/api/src/suggestions/dto/create-suggestion.dto.ts
+++ b/api/src/suggestions/dto/create-suggestion.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateSuggestionDto {
   @IsNotEmpty()
@@ -17,7 +17,4 @@ export class CreateSuggestionDto {
   @IsString()
   categoryId: string;
 
-  @IsNotEmpty()
-  @IsNumber()
-  userId: number;
 }

--- a/api/src/suggestions/suggestions.controller.spec.ts
+++ b/api/src/suggestions/suggestions.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SuggestionsController } from './suggestions.controller';
 import { SuggestionsService } from './suggestions.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('SuggestionsController', () => {
   let controller: SuggestionsController;
@@ -8,7 +9,13 @@ describe('SuggestionsController', () => {
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SuggestionsController],
-      providers: [SuggestionsService],
+      providers: [
+        SuggestionsService,
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     controller = module.get<SuggestionsController>(SuggestionsController);

--- a/api/src/suggestions/suggestions.controller.ts
+++ b/api/src/suggestions/suggestions.controller.ts
@@ -1,17 +1,33 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
 import { SuggestionsService } from './suggestions.service';
 import { CreateSuggestionDto } from './dto/create-suggestion.dto';
 import { UpdateSuggestionDto } from './dto/update-suggestion.dto';
 import { ApiTags } from '@nestjs/swagger';
+import { AuthenticatedUserGuard } from 'src/common/guards/authenticated-user.guard';
+import { CurrentUser } from 'src/common/decorators/current-user.decorator';
+import { AuthenticatedUser } from 'src/common/interfaces/authenticated-user.interface';
 
 @Controller('suggestions')
 @ApiTags("Suggestions")
 export class SuggestionsController {
   constructor(private readonly suggestionsService: SuggestionsService) { }
 
+  @UseGuards(AuthenticatedUserGuard)
   @Post()
-  create(@Body() createSuggestionDto: CreateSuggestionDto) {
-    return this.suggestionsService.create(createSuggestionDto);
+  create(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() createSuggestionDto: CreateSuggestionDto,
+  ) {
+    return this.suggestionsService.create(user.id, createSuggestionDto);
   }
 
   @Get()

--- a/api/src/suggestions/suggestions.service.spec.ts
+++ b/api/src/suggestions/suggestions.service.spec.ts
@@ -1,12 +1,19 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { SuggestionsService } from './suggestions.service';
+import { PrismaService } from 'src/prisma/prisma.service';
 
 describe('SuggestionsService', () => {
   let service: SuggestionsService;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [SuggestionsService],
+      providers: [
+        SuggestionsService,
+        {
+          provide: PrismaService,
+          useValue: {},
+        },
+      ],
     }).compile();
 
     service = module.get<SuggestionsService>(SuggestionsService);

--- a/api/src/suggestions/suggestions.service.ts
+++ b/api/src/suggestions/suggestions.service.ts
@@ -8,16 +8,20 @@ import { UpdateSuggestionDto } from "./dto/update-suggestion.dto";
 export class SuggestionsService {
   constructor(private prisma: PrismaService) { }
 
-  async create(createSuggestionDto: CreateSuggestionDto) {
-    const { name, link, description, categoryId, userId } = createSuggestionDto;
+  async create(userId: number, createSuggestionDto: CreateSuggestionDto) {
+    const { name, link, description, categoryId } = createSuggestionDto;
 
-
-    const user = await this.prisma.user.findUnique({
-      where: { githubId: userId },
-    });
+    const [user, category] = await Promise.all([
+      this.prisma.user.findUnique({ where: { githubId: userId } }),
+      this.prisma.category.findUnique({ where: { id: categoryId } }),
+    ]);
 
     if (!user) {
       throw new NotFoundException('User not found');
+    }
+
+    if (!category) {
+      throw new NotFoundException('Category not found');
     }
 
     return this.prisma.sugestion.create({

--- a/web/src/app/api/auth/[...nextauth]/route.js
+++ b/web/src/app/api/auth/[...nextauth]/route.js
@@ -3,7 +3,7 @@ import GithubProvider from 'next-auth/providers/github';
 import { AxiosConfig } from '@/utils';
 
 // Configuração do NextAuth (não exportada)
-const authOptions = {
+export const authOptions = {
   providers: [
     GithubProvider({
       clientId: process.env.GITHUB_ID,

--- a/web/src/app/favorites/FavoritesContent.js
+++ b/web/src/app/favorites/FavoritesContent.js
@@ -1,0 +1,42 @@
+'use client'
+
+import Card from '@/components/Card'
+import { useState } from 'react'
+
+export default function FavoritesContent({ initialFavorites }) {
+  const [favorites, setFavorites] = useState(initialFavorites ?? [])
+
+  const handleFavoriteChange = (toolId, isFavorite) => {
+    if (!isFavorite) {
+      setFavorites(prev => prev.filter(favorite => favorite.toolId !== toolId))
+    }
+  }
+
+  if (!favorites.length) {
+    return (
+      <div className='flex flex-col justify-center items-center h-screen'>
+        <h2 className='text-xl font-semibold mb-4'>No favorites found</h2>
+        <p className='text-gray-600'>
+          You haven't added any tools to your favorites yet.
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className='w-4/5 mx-auto py-8'>
+      <h1 className='text-2xl font-bold mb-6'>My Favorites</h1>
+      <div className='grid grid-cols-1 tablet:grid-cols-2 desktop:grid-cols-5 gap-5'>
+        {favorites.map(favorite => (
+          <div key={favorite.id}>
+            <Card
+              tool={favorite.tool}
+              initialIsFavorite
+              onFavoriteChange={handleFavoriteChange}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/app/favorites/page.js
+++ b/web/src/app/favorites/page.js
@@ -1,29 +1,43 @@
 import { authOptions } from '@/app/api/auth/[...nextauth]/route'
-import Card from '@/components/Card'
+import FavoritesContent from './FavoritesContent'
 import { getServerSession } from 'next-auth'
+import { getApiBaseUrl } from '@/utils'
 
 export const metadata = {
   title: 'Favorites - Tools4.tech',
 }
 
 async function getFavorites(userId) {
+  if (!userId) {
+    return []
+  }
+
   try {
+    const baseUrl = getApiBaseUrl()
+
+    if (!baseUrl) {
+      return []
+    }
+
     const response = await fetch(
-      `${process.env.URL_API}/favorites/user/${userId}`,
+      `${baseUrl}/favorites/user/${userId}`,
       {
         method: 'GET',
         cache: 'no-store',
+        headers: {
+          'x-user-id': String(userId),
+        },
       },
     )
 
     if (!response.ok) {
-      return null
+      return []
     }
 
     const data = await response.json()
     return data
   } catch (error) {
-    return null
+    return []
   }
 }
 
@@ -41,30 +55,20 @@ export default async function Favorites() {
     )
   }
 
-  const favorites = await getFavorites(session?.user?.githubId)
+  const userId = session?.user?.githubId
 
-  if (!favorites || favorites.length === 0) {
+  if (!userId) {
     return (
       <div className='flex flex-col justify-center items-center h-screen'>
-        <h2 className='text-xl font-semibold mb-4'>No favorites found</h2>
-        <p className='text-gray-600'>
-          You haven't added any tools to your favorites yet.
-        </p>
+        <h2 className='text-xl font-semibold mb-4'>
+          We couldn't load your favorites
+        </h2>
+        <p className='text-gray-600'>Try signing out and back in again.</p>
       </div>
     )
   }
 
-  return (
-    <div className='w-4/5 mx-auto py-8'>
-      <h1 className='text-2xl font-bold mb-6'>My Favorites</h1>
-      <div className='grid grid-cols-1 tablet:grid-cols-2 desktop:grid-cols-5 gap-5'>
-        {favorites &&
-          favorites.map(fav => (
-            <div key={fav.id}>
-              <Card tool={fav.tool} isFavorite={true} favoriteId={fav.id} />
-            </div>
-          ))}
-      </div>
-    </div>
-  )
+  const favorites = await getFavorites(userId)
+
+  return <FavoritesContent initialFavorites={favorites} />
 }

--- a/web/src/components/AddSuggestionModal.js
+++ b/web/src/components/AddSuggestionModal.js
@@ -9,11 +9,6 @@ async function fetchCategories() {
   return data
 }
 
-async function createSuggestion(suggestionData) {
-  const { data } = await AxiosConfig.post('/suggestions', suggestionData)
-  return data
-}
-
 export default function AddSuggestionModal({ isOpen, onClose, onSubmit }) {
   const { data: session, status } = useSession()
   const [name, setName] = useState('')
@@ -29,10 +24,16 @@ export default function AddSuggestionModal({ isOpen, onClose, onSubmit }) {
   } = useQuery({
     queryKey: ['categories'],
     queryFn: fetchCategories,
+    enabled: isOpen,
   })
 
   const mutation = useMutation({
-    mutationFn: createSuggestion,
+    mutationFn: suggestionData =>
+      AxiosConfig.post('/suggestions', suggestionData, {
+        headers: {
+          'x-user-id': String(session?.user?.githubId),
+        },
+      }).then(response => response.data),
     onSuccess: data => {
       setName('')
       setLink('')
@@ -41,10 +42,16 @@ export default function AddSuggestionModal({ isOpen, onClose, onSubmit }) {
 
       onClose()
 
-      onSubmit(data)
+      onSubmit?.({ status: 'success', data })
     },
     onError: error => {
       console.error('Error creating suggestion:', error)
+      onSubmit?.({
+        status: 'error',
+        message:
+          error.response?.data?.message ||
+          'Error sending suggestion. Please try again.',
+      })
     },
   })
 
@@ -61,7 +68,6 @@ export default function AddSuggestionModal({ isOpen, onClose, onSubmit }) {
       link,
       description,
       categoryId,
-      userId: session.user.githubId,
     }
 
     mutation.mutate(suggestionData)
@@ -72,6 +78,7 @@ export default function AddSuggestionModal({ isOpen, onClose, onSubmit }) {
       document.body.style.overflow = 'hidden'
     } else {
       document.body.style.overflow = 'unset'
+      setIsSelectOpen(false)
     }
     return () => {
       document.body.style.overflow = 'unset'

--- a/web/src/components/Card.js
+++ b/web/src/components/Card.js
@@ -7,22 +7,39 @@ import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { Toast } from './Toast'
 
-export default function Card({ tool, onFavoriteChange }) {
+export default function Card({ tool, initialIsFavorite = false, onFavoriteChange }) {
   const { data: session, status } = useSession()
   const [toast, setToast] = useState(null)
-  const [isFavorite, setIsFavorite] = useState(false)
+  const [isFavorite, setIsFavorite] = useState(initialIsFavorite)
 
   useEffect(() => {
-    if (status === 'authenticated' && session?.user?.githubId) {
+    setIsFavorite(initialIsFavorite)
+  }, [initialIsFavorite])
+
+  useEffect(() => {
+    if (
+      status === 'authenticated' &&
+      session?.user?.githubId &&
+      !initialIsFavorite
+    ) {
       fetchFavoriteStatus()
     }
-  }, [session, status])
+
+    if (status === 'unauthenticated') {
+      setIsFavorite(false)
+    }
+  }, [session, status, initialIsFavorite, tool.id])
 
   const fetchFavoriteStatus = async () => {
     try {
-      const response = await AxiosConfig.get(
-        `/favorites/check?userId=${session.user.githubId}&toolId=${tool.id}`,
-      )
+      const response = await AxiosConfig.get('/favorites/check', {
+        params: {
+          toolId: tool.id,
+        },
+        headers: {
+          'x-user-id': String(session.user.githubId),
+        },
+      })
       setIsFavorite(response.data.isFavorite)
     } catch (error) {
       console.error('Error checking favorite', error)
@@ -41,14 +58,21 @@ export default function Card({ tool, onFavoriteChange }) {
       return
     }
 
+    const previousFavoriteStatus = isFavorite
+
     try {
-      const newFavoriteStatus = !isFavorite
+      const newFavoriteStatus = !previousFavoriteStatus
       setIsFavorite(newFavoriteStatus)
 
-      const response = await AxiosConfig.post('/favorites/toggle', {
-        userId: session.user.githubId,
-        toolId: tool.id,
-      })
+      await AxiosConfig.post(
+        '/favorites/toggle',
+        { toolId: tool.id },
+        {
+          headers: {
+            'x-user-id': String(session.user.githubId),
+          },
+        },
+      )
 
       setToast({
         message: `${tool.name} ${
@@ -61,13 +85,14 @@ export default function Card({ tool, onFavoriteChange }) {
         onFavoriteChange(tool.id, newFavoriteStatus)
       }
     } catch (error) {
-      setIsFavorite(isFavorite)
+      setIsFavorite(previousFavoriteStatus)
       console.error(
         'Error updating favorites:',
         error.response ? error.response.data : error.message,
       )
       setToast({
         message:
+          error.response?.data?.message ||
           'An error occurred while updating favorites. Please try again.',
         type: 'error',
       })

--- a/web/src/components/Navbar.js
+++ b/web/src/components/Navbar.js
@@ -42,11 +42,14 @@ export default function Navbar() {
     setIsModalOpen(true)
   }
 
-  const handleModalSubmit = async suggestionData => {
-    try {
+  const handleModalSubmit = result => {
+    if (result?.status === 'success') {
       showToast('Suggestion sent successfully!', 'success')
-    } catch (error) {
-      showToast('Error sending suggestion. Please try again.', 'error')
+      return
+    }
+
+    if (result?.status === 'error') {
+      showToast(result.message || 'Error sending suggestion. Please try again.', 'error')
     }
   }
 

--- a/web/src/utils/axiosConfig.js
+++ b/web/src/utils/axiosConfig.js
@@ -1,7 +1,10 @@
 import axios from 'axios'
 
+const baseURL =
+  process.env.NEXT_PUBLIC_URL_API || process.env.URL_API || undefined
+
 const AxiosConfig = axios.create({
-  baseURL: process.env.NEXT_PUBLIC_URL_API,
+  baseURL,
 })
 
 export default AxiosConfig

--- a/web/src/utils/getApiBaseUrl.js
+++ b/web/src/utils/getApiBaseUrl.js
@@ -1,0 +1,5 @@
+const getApiBaseUrl = () => {
+  return process.env.URL_API || process.env.NEXT_PUBLIC_URL_API || ''
+}
+
+export default getApiBaseUrl

--- a/web/src/utils/index.js
+++ b/web/src/utils/index.js
@@ -1,3 +1,4 @@
 export { default as AxiosConfig } from './axiosConfig'
 export { default as cn } from './cn'
 export { default as GetRepoStars } from './getRepoStars'
+export { default as getApiBaseUrl } from './getApiBaseUrl'


### PR DESCRIPTION
## Summary
- add a reusable guard/decorator for extracting the authenticated user id from requests and secure favorites/suggestions endpoints
- improve favorites persistence with stricter Prisma constraints, explicit validation, and Prisma service lifecycle hooks
- align the Next.js client with the new contract by propagating the user id via headers, refreshing UI state locally, and surfacing suggestion errors

## Testing
- `npm run lint` *(fails: ESLint configuration missing in api project)*
- `npm run lint` *(fails: Next.js lint prompts for config in web project)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ea62d0dc832fa5fcdfc41a6bd077