### PR TITLE
Improve favorite toggling concurrency safety

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -59,6 +59,9 @@
     "typescript": "^5.1.3"
   },
   "jest": {
+    "moduleNameMapper": {
+      "^src/(.*)$": "<rootDir>/$1"
+    },
     "moduleFileExtensions": [
       "js",
       "json",

--- a/api/src/favorites/favorites.controller.spec.ts
+++ b/api/src/favorites/favorites.controller.spec.ts
@@ -1,27 +1,54 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { FavoritesController } from './favorites.controller';
 import { FavoritesService } from './favorites.service';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { FakePrismaService } from './testing/fake-prisma.service';
 
 describe('FavoritesController', () => {
   let controller: FavoritesController;
+  let service: FavoritesService;
+  let prisma: FakePrismaService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      controllers: [FavoritesController],
-      providers: [
-        FavoritesService,
-        {
-          provide: PrismaService,
-          useValue: {},
-        },
-      ],
-    }).compile();
+  const userId = 123;
+  const toolId = '00000000-0000-0000-0000-000000000001';
 
-    controller = module.get<FavoritesController>(FavoritesController);
+  beforeEach(() => {
+    prisma = new FakePrismaService();
+    prisma.seedUser(userId);
+    prisma.seedTool(toolId);
+
+    service = new FavoritesService(prisma as any);
+    controller = new FavoritesController(service);
   });
 
   it('should be defined', () => {
     expect(controller).toBeDefined();
+  });
+
+  describe('toggleFavorite', () => {
+    it('should respond successfully when concurrent requests favorite the same tool', async () => {
+      prisma.createBarrier('favorite.findFirst', 2);
+
+      const [first, second] = await Promise.all([
+        controller.toggleFavorite(userId, toolId),
+        controller.toggleFavorite(userId, toolId),
+      ]);
+
+      expect(first).toEqual({ isFavorite: true });
+      expect(second).toEqual({ isFavorite: true });
+      expect(prisma.favoriteCount()).toBe(1);
+    });
+
+    it('should respond successfully when concurrent requests unfavorite the same tool', async () => {
+      prisma.seedFavorite(userId, toolId);
+      prisma.createBarrier('favorite.findFirst', 2);
+
+      const [first, second] = await Promise.all([
+        controller.toggleFavorite(userId, toolId),
+        controller.toggleFavorite(userId, toolId),
+      ]);
+
+      expect(first).toEqual({ isFavorite: false });
+      expect(second).toEqual({ isFavorite: false });
+      expect(prisma.favoriteCount()).toBe(0);
+    });
   });
 });

--- a/api/src/favorites/favorites.service.spec.ts
+++ b/api/src/favorites/favorites.service.spec.ts
@@ -1,25 +1,51 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { FavoritesService } from './favorites.service';
-import { PrismaService } from 'src/prisma/prisma.service';
+import { FakePrismaService } from './testing/fake-prisma.service';
 
 describe('FavoritesService', () => {
   let service: FavoritesService;
+  let prisma: FakePrismaService;
 
-  beforeEach(async () => {
-    const module: TestingModule = await Test.createTestingModule({
-      providers: [
-        FavoritesService,
-        {
-          provide: PrismaService,
-          useValue: {},
-        },
-      ],
-    }).compile();
+  const userId = 123;
+  const toolId = '00000000-0000-0000-0000-000000000001';
 
-    service = module.get<FavoritesService>(FavoritesService);
+  beforeEach(() => {
+    prisma = new FakePrismaService();
+    prisma.seedUser(userId);
+    prisma.seedTool(toolId);
+
+    service = new FavoritesService(prisma as any);
   });
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('toggleFavorite', () => {
+    it('should resolve concurrent favorite toggles without conflicts', async () => {
+    prisma.createBarrier('favorite.findFirst', 2);
+
+      const [first, second] = await Promise.all([
+        service.toggleFavorite(userId, toolId),
+        service.toggleFavorite(userId, toolId),
+      ]);
+
+      expect(first).toEqual({ isFavorite: true });
+      expect(second).toEqual({ isFavorite: true });
+      expect(prisma.favoriteCount()).toBe(1);
+    });
+
+    it('should resolve concurrent unfavorite toggles without conflicts', async () => {
+      prisma.seedFavorite(userId, toolId);
+      prisma.createBarrier('favorite.findFirst', 2);
+
+      const [first, second] = await Promise.all([
+        service.toggleFavorite(userId, toolId),
+        service.toggleFavorite(userId, toolId),
+      ]);
+
+      expect(first).toEqual({ isFavorite: false });
+      expect(second).toEqual({ isFavorite: false });
+      expect(prisma.favoriteCount()).toBe(0);
+    });
   });
 });

--- a/api/src/favorites/favorites.service.ts
+++ b/api/src/favorites/favorites.service.ts
@@ -46,12 +46,10 @@ export class FavoritesService {
   }
 
   async checkFavorite(userId: number, toolId: string) {
-    const favorite = await this.prisma.favorite.findUnique({
+    const favorite = await this.prisma.favorite.findFirst({
       where: {
-        userId_toolId: {
-          userId,
-          toolId,
-        },
+        userId,
+        toolId,
       },
     });
     return { isFavorite: !!favorite };
@@ -65,39 +63,55 @@ export class FavoritesService {
   }
 
   async toggleFavorite(userId: number, toolId: string) {
-    const [user, tool] = await Promise.all([
-      this.prisma.user.findUnique({ where: { githubId: userId } }),
-      this.prisma.tool.findUnique({ where: { id: toolId } }),
-    ]);
+    return this.prisma.$transaction(async (tx) => {
+      const [user, tool] = await Promise.all([
+        tx.user.findUnique({ where: { githubId: userId } }),
+        tx.tool.findUnique({ where: { id: toolId } }),
+      ]);
 
-    if (!user) {
-      throw new NotFoundException("User not found");
-    }
+      if (!user) {
+        throw new NotFoundException("User not found");
+      }
 
-    if (!tool) {
-      throw new NotFoundException("Tool not found");
-    }
+      if (!tool) {
+        throw new NotFoundException("Tool not found");
+      }
 
-    const existingFavorite = await this.prisma.favorite.findUnique({
-      where: {
-        userId_toolId: {
+      const existingFavorite = await tx.favorite.findFirst({
+        where: {
           userId,
           toolId,
         },
-      },
-    });
+      });
 
-    if (existingFavorite) {
-      await this.prisma.favorite.delete({
-        where: { id: existingFavorite.id },
-      });
-      return { isFavorite: false };
-    } else {
-      await this.prisma.favorite.create({
-        data: { userId, toolId },
-      });
-      return { isFavorite: true };
-    }
+      if (existingFavorite) {
+        await tx.favorite.deleteMany({
+          where: {
+            userId,
+            toolId,
+          },
+        });
+
+        return { isFavorite: false };
+      }
+
+      try {
+        await tx.favorite.create({
+          data: { userId, toolId },
+        });
+
+        return { isFavorite: true };
+      } catch (error) {
+        if (
+          error instanceof Prisma.PrismaClientKnownRequestError &&
+          error.code === "P2002"
+        ) {
+          return { isFavorite: true };
+        }
+
+        throw error;
+      }
+    });
   }
 
   update(id: string, updateFavoriteDto: UpdateFavoriteDto) {

--- a/api/src/favorites/testing/fake-prisma.service.ts
+++ b/api/src/favorites/testing/fake-prisma.service.ts
@@ -1,0 +1,211 @@
+import { Prisma } from '@prisma/client';
+
+type FavoriteRecord = { id: string; userId: number; toolId: string };
+
+class Barrier {
+  private readonly parties: number;
+  private count = 0;
+  private resolvers: Array<() => void> = [];
+  private released = false;
+
+  constructor(parties: number) {
+    this.parties = parties;
+  }
+
+  async wait() {
+    if (this.released) {
+      return;
+    }
+
+    this.count += 1;
+
+    if (this.count >= this.parties) {
+      this.released = true;
+      this.resolvers.forEach((resolve) => resolve());
+      this.resolvers = [];
+      return;
+    }
+
+    await new Promise<void>((resolve) => this.resolvers.push(resolve));
+  }
+
+  isReleased() {
+    return this.released;
+  }
+}
+
+export class FakePrismaService {
+  private users = new Map<number, { githubId: number }>();
+  private tools = new Map<string, { id: string }>();
+  private favorites = new Map<string, FavoriteRecord>();
+  private barriers = new Map<string, Barrier>();
+  private idCounter = 0;
+
+  user = {
+    findUnique: this.userFindUnique.bind(this),
+  };
+
+  tool = {
+    findUnique: this.toolFindUnique.bind(this),
+  };
+
+  favorite = {
+    findFirst: this.favoriteFindFirst.bind(this),
+    findUnique: this.favoriteFindUnique.bind(this),
+    create: this.favoriteCreate.bind(this),
+    deleteMany: this.favoriteDeleteMany.bind(this),
+  };
+
+  async $transaction<T>(callback: (tx: any) => Promise<T>) {
+    return callback({
+      user: { findUnique: this.userFindUnique.bind(this) },
+      tool: { findUnique: this.toolFindUnique.bind(this) },
+      favorite: {
+        findFirst: this.favoriteFindFirst.bind(this),
+        findUnique: this.favoriteFindUnique.bind(this),
+        create: this.favoriteCreate.bind(this),
+        deleteMany: this.favoriteDeleteMany.bind(this),
+      },
+    });
+  }
+
+  seedUser(id: number) {
+    this.users.set(id, { githubId: id });
+  }
+
+  seedTool(id: string) {
+    this.tools.set(id, { id });
+  }
+
+  seedFavorite(userId: number, toolId: string) {
+    const key = this.favoriteKey(userId, toolId);
+    this.favorites.set(key, {
+      id: `fav-${++this.idCounter}`,
+      userId,
+      toolId,
+    });
+  }
+
+  favoriteCount() {
+    return this.favorites.size;
+  }
+
+  createBarrier(name: string, parties: number) {
+    this.barriers.set(name, new Barrier(parties));
+  }
+
+  private async waitOnBarrier(name: string) {
+    const barrier = this.barriers.get(name);
+    if (!barrier) {
+      return;
+    }
+
+    await barrier.wait();
+
+    if (barrier.isReleased()) {
+      this.barriers.delete(name);
+    }
+  }
+
+  private favoriteKey(userId: number, toolId: string) {
+    return `${userId}:${toolId}`;
+  }
+
+  private async userFindUnique(args: { where: { githubId?: number; id?: number } }) {
+    await Promise.resolve();
+    const { where } = args;
+
+    if (where.githubId !== undefined) {
+      return this.users.get(where.githubId) ?? null;
+    }
+
+    if (where.id !== undefined) {
+      return this.users.get(where.id) ?? null;
+    }
+
+    return null;
+  }
+
+  private async toolFindUnique(args: { where: { id: string } }) {
+    await Promise.resolve();
+    return this.tools.get(args.where.id) ?? null;
+  }
+
+  private async favoriteFindUnique(args: {
+    where:
+      | { userId_toolId: { userId: number; toolId: string } }
+      | { id: string };
+  }) {
+    await this.waitOnBarrier('favorite.findUnique');
+    await this.waitOnBarrier('favorite.findFirst');
+    await Promise.resolve();
+
+    if ('userId_toolId' in args.where) {
+      const { userId, toolId } = args.where.userId_toolId;
+      return this.favorites.get(this.favoriteKey(userId, toolId)) ?? null;
+    }
+
+    const { id } = args.where as { id: string };
+    for (const favorite of this.favorites.values()) {
+      if (favorite.id === id) {
+        return favorite;
+      }
+    }
+
+    return null;
+  }
+
+  private async favoriteFindFirst(args: { where?: { userId?: number; toolId?: string } }) {
+    await this.waitOnBarrier('favorite.findUnique');
+    await this.waitOnBarrier('favorite.findFirst');
+    await Promise.resolve();
+
+    const { where } = args;
+    if (!where) {
+      const [first] = this.favorites.values();
+      return first ?? null;
+    }
+
+    const { userId, toolId } = where;
+
+    if (userId !== undefined && toolId !== undefined) {
+      return this.favorites.get(this.favoriteKey(userId, toolId)) ?? null;
+    }
+
+    for (const favorite of this.favorites.values()) {
+      if (
+        (userId === undefined || favorite.userId === userId) &&
+        (toolId === undefined || favorite.toolId === toolId)
+      ) {
+        return favorite;
+      }
+    }
+
+    return null;
+  }
+
+  private async favoriteCreate(args: { data: { userId: number; toolId: string } }) {
+    await Promise.resolve();
+    const { userId, toolId } = args.data;
+    const key = this.favoriteKey(userId, toolId);
+
+    if (this.favorites.has(key)) {
+      throw new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+        code: 'P2002',
+        clientVersion: 'fake',
+      });
+    }
+
+    const favorite = { id: `fav-${++this.idCounter}`, userId, toolId };
+    this.favorites.set(key, favorite);
+    return favorite;
+  }
+
+  private async favoriteDeleteMany(args: { where: { userId: number; toolId: string } }) {
+    await Promise.resolve();
+    const { userId, toolId } = args.where;
+    const key = this.favoriteKey(userId, toolId);
+    const existed = this.favorites.delete(key);
+    return { count: existed ? 1 : 0 };
+  }
+}

--- a/api/src/prisma/prisma.service.ts
+++ b/api/src/prisma/prisma.service.ts
@@ -8,7 +8,7 @@ export class PrismaService extends PrismaClient implements OnModuleInit {
   }
 
   async enableShutdownHooks(app: INestApplication) {
-    this.$on('beforeExit', async () => {
+    this.$on('beforeExit' as never, async () => {
       await app.close();
     });
   }


### PR DESCRIPTION
## Summary
- execute the favorites toggle inside a Prisma transaction, using deleteMany for removals and handling duplicate create races
- add a reusable FakePrismaService plus service/controller specs that issue concurrent toggle calls to assert consistent responses
- configure Jest path mapping for `src/*` imports and adjust PrismaService shutdown hook typing for compatibility

## Testing
- npm test -- favorites/favorites.service.spec.ts
- npm test -- favorites/favorites.controller.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68ca08becae4832f81a9ee1d0ba8b9b5